### PR TITLE
Fix reinterpret expression as pattern

### DIFF
--- a/esprima/parser.py
+++ b/esprima/parser.py
@@ -925,18 +925,22 @@ class Parser(object):
             pass
         elif typ is Syntax.SpreadElement:
             expr.type = Syntax.RestElement
+            expr.__class__ = Node.RestElement
             self.reinterpretExpressionAsPattern(expr.argument)
         elif typ is Syntax.ArrayExpression:
             expr.type = Syntax.ArrayPattern
+            expr.__class__ = Node.ArrayPattern
             for elem in expr.elements:
                 if elem is not None:
                     self.reinterpretExpressionAsPattern(elem)
         elif typ is Syntax.ObjectExpression:
             expr.type = Syntax.ObjectPattern
+            expr.__class__ = Node.ObjectPattern
             for prop in expr.properties:
                 self.reinterpretExpressionAsPattern(prop if prop.type is Syntax.SpreadElement else prop.value)
         elif typ is Syntax.AssignmentExpression:
             expr.type = Syntax.AssignmentPattern
+            expr.__class__ = Node.AssignmentPattern
             del expr.operator
             self.reinterpretExpressionAsPattern(expr.left)
         else:

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -196,6 +196,22 @@ class TestEsprima(unittest.TestCase):
         r = parse(script)
         self.assertIsInstance(r, Script)
 
+    def test_reinterpret_as_pattern_python_class(self):
+        def arrow_param(src):
+            return parse(src).body[0].expression.arguments[0].params[0]
+
+        from esprima import nodes
+        cases = [
+            ("f(({x}) => x)",      nodes.ObjectPattern),
+            ("f(([x]) => x)",      nodes.ArrayPattern),
+            ("f(({x} = {}) => x)", nodes.AssignmentPattern),
+            ("f((...x) => x)",     nodes.RestElement),
+        ]
+        for src, expected_class in cases:
+            with self.subTest(src=src):
+                node = arrow_param(src)
+                self.assertIsInstance(node, expected_class)
+
     def test_bigint_literals(self):
         """Test BigInt literal parsing for all number bases"""
         # Test decimal BigInt


### PR DESCRIPTION
# `ObjectPattern` in arrow function parameters instantiated as `ObjectExpression`

When an arrow function has an object destructuring parameter — e.g. `({x}) => x` — the resulting AST node has `.type == "ObjectPattern"` (correct) but its Python class is `ObjectExpression` (wrong). Every other destructuring context produces the correct `ObjectPattern` class.

## Reproduction

```python
import esprima
import esprima.nodes as nodes

def node_of(src):
    # arrow function parameter
    return esprima.parseScript(src).body[0].expression.arguments[0].params[0]

node = node_of("f(({x}) => x)")

print(node.type)                              # "ObjectPattern"  ✓ correct
print(type(node).__name__)                    # "ObjectExpression"  ✗ wrong
print(isinstance(node, nodes.ObjectPattern))  # False  ✗ wrong
```

## Expected

`isinstance(node, nodes.ObjectPattern)` should be `True`, consistent with the other three destructuring contexts:

| Context | Python class | `.type` | `isinstance(ObjectPattern)` |
|---|---|---|---|
| Arrow function param `({x}) => x` | `ObjectExpression` | `ObjectPattern` | **False ✗** |
| Regular function param `function f({x}) {}` | `ObjectPattern` | `ObjectPattern` | True ✓ |
| `for…of` `for (const {x} of xs) {}` | `ObjectPattern` | `ObjectPattern` | True ✓ |
| Variable `var {x} = obj` | `ObjectPattern` | `ObjectPattern` | True ✓ |

## Workaround

Check `node.type == "ObjectPattern"` instead of `isinstance(node, nodes.ObjectPattern)`.

## Environment

- esprima 4.0.1
- Python 3.14.4
